### PR TITLE
fixed shading

### DIFF
--- a/lib/FHEM/Automation/ShuttersControl.pm
+++ b/lib/FHEM/Automation/ShuttersControl.pm
@@ -175,8 +175,8 @@ BEGIN {
 ## Die Attributsliste welche an die Rolläden verteilt wird. Zusammen mit Default Werten
 ##no critic
 our %userAttrList = (
-    'ASC_Mode_Up:absent,always,off,home'                            => '-',
-    'ASC_Mode_Down:absent,always,off,home'                          => '-',
+    'ASC_Mode_Up:absent,always,off,home,gone'                       => '-',
+    'ASC_Mode_Down:absent,always,off,home,gone'                     => '-',
     'ASC_Up:time,astro,brightness,roommate'                         => '-',
     'ASC_Down:time,astro,brightness,roommate'                       => '-',
     'ASC_AutoAstroModeMorning:REAL,CIVIL,NAUTIC,ASTRONOMIC,HORIZON' => '-',
@@ -207,7 +207,7 @@ our %userAttrList = (
     'ASC_BlockingTime_beforeDayOpen'                       => '-',
     'ASC_BrightnessSensor'                                 => '-',
     'ASC_Shading_Pos:10,20,30,40,50,60,70,80,90,100'       => [ '', 80, 20 ],
-    'ASC_Shading_Mode:absent,always,off,home'              => '-',
+    'ASC_Shading_Mode:absent,always,off,home,gone'         => '-',
     'ASC_Shading_InOutAzimuth'                             => '-',
     'ASC_Shading_StateChange_SunnyCloudy'                  => '-',
     'ASC_Shading_MinMax_Elevation'                         => '-',
@@ -1925,9 +1925,15 @@ sub ASC_Debug {
     my $debugMsg       = shift;
     my $debugTimestamp = strftime( "%Y.%m.%d %T", localtime(time) );
 
+#    print(
+#        encode_utf8(
+#            "\n" . 'ASC_DEBUG!!! ' . $debugTimestamp . ' - ' . $debugMsg . "\n"
+#        )
+#    );
+
     print(
         encode_utf8(
-            "\n" . 'ASC_DEBUG!!! ' . $debugTimestamp . ' - ' . $debugMsg . "\n"
+            'ASC_DEBUG!!! ' . $debugTimestamp . ' - ' . $debugMsg . "\n"
         )
     );
 

--- a/lib/FHEM/Automation/ShuttersControl/EventProcessingFunctions.pm
+++ b/lib/FHEM/Automation/ShuttersControl/EventProcessingFunctions.pm
@@ -376,8 +376,12 @@ sub EventProcessingWindowRec {
                     || $homemode eq 'none' )
                 && $FHEM::Automation::ShuttersControl::shutters->getModeUp ne
                 'absent'
-                && $FHEM::Automation::ShuttersControl::shutters->getModeUp ne
-                'off'
+    #           disabled by postfux to also drive from Ventialte Position when 
+    #           WindowContact closes, even if ModeDown is off.
+    #           there is not such check when WindowContact ist opened 
+    #           so it always drives to Ventilate Position.
+    #            && $FHEM::Automation::ShuttersControl::shutters->getModeUp ne
+    #            'off'
               )
             {
                 if (
@@ -477,8 +481,12 @@ sub EventProcessingWindowRec {
             elsif (
                 $FHEM::Automation::ShuttersControl::shutters->getModeDown ne
                 'absent'
-                && $FHEM::Automation::ShuttersControl::shutters->getModeDown ne
-                'off'
+    #           disabled by postfux to also drive from Ventialte Position when 
+    #           WindowContact closes, even if ModeDown is off.
+    #           there is not such check when WindowContact ist opened 
+    #           so it always drives to Ventilate Position.
+    #            && $FHEM::Automation::ShuttersControl::shutters->getModeDown ne
+    #            'off'
                 && (
                     (
                         !$FHEM::Automation::ShuttersControl::shutters->getIsDay
@@ -618,7 +626,7 @@ sub EventProcessingRoommate {
     my $reading =
       $FHEM::Automation::ShuttersControl::shutters->getRoommatesReading;
 
-    if ( $events =~ m{$reading:\s(absent|gotosleep|asleep|awoken|home)}xms ) {
+    if ( $events =~ m{$reading:\s(absent|gotosleep|asleep|awoken|home|gone)}xms ) {
         ::Log3( $name, 4,
             "AutoShuttersControl ($name) - EventProcessingRoommate: "
               . $FHEM::Automation::ShuttersControl::shutters
@@ -721,6 +729,9 @@ sub EventProcessingRoommate {
                 && $getRoommatesStatus eq 'home'
               )
             {
+                ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate_3: $shuttersDev und Events $events"
+                );
                 if (
                        $getIsDay
                     && $FHEM::Automation::ShuttersControl::shutters
@@ -737,6 +748,8 @@ sub EventProcessingRoommate {
                     )
                     && !$FHEM::Automation::ShuttersControl::shutters
                     ->getSelfDefenseState
+                   && (($FHEM::Automation::ShuttersControl::shutters
+                        ->getShadingMode eq 'home' ) ) # added by postfux for not Shading when change form absent or gone to home
                   )
                 {
                     ShadingProcessingDriveCommand( $hash, $shuttersDev, 1 );
@@ -971,8 +984,83 @@ sub EventProcessingRoommate {
 "AutoShuttersControl ($name) - EventProcessingRoommate NICHTS: $shuttersDev"
             );
         }
-    }
+    elsif (  #postfux added rommate gone condition
+            $event eq 'gone'
+            && (  !$getIsDay
+                || $getDown eq 'roommate'
+                || $FHEM::Automation::ShuttersControl::shutters->getShadingMode
+                eq 'gone'
+                || $FHEM::Automation::ShuttersControl::shutters->getModeUp eq
+                'gone'
+                || $FHEM::Automation::ShuttersControl::shutters->getModeDown eq
+                'gone' )
+          )
+        {
+            ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate gone: $shuttersDev"
+            );
 
+            if (
+                   $getIsDay
+                && $FHEM::Automation::ShuttersControl::shutters->getIfInShading
+                && !$FHEM::Automation::ShuttersControl::shutters
+                ->getQueryShuttersPos(
+                    $FHEM::Automation::ShuttersControl::shutters->getShadingPos
+                )
+                && $FHEM::Automation::ShuttersControl::shutters->getShadingMode
+                eq 'gone'
+              )
+            {
+                ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate Shading: $shuttersDev"
+                );
+
+                $FHEM::Automation::ShuttersControl::shutters->setLastDrive(
+                    'shading in');
+                FHEM::Automation::ShuttersControl::ShuttersCommandSet(
+                    $hash,
+                    $shuttersDev,
+                    $FHEM::Automation::ShuttersControl::shutters->getShadingPos
+                );
+            }
+            elsif (( !$getIsDay || $getDown eq 'roommate' )
+                && $getModeDown eq 'gone'
+                && $getRoommatesStatus eq 'gone' )
+            {
+                ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate Down: $shuttersDev"
+                );
+
+                $FHEM::Automation::ShuttersControl::shutters->setLastDrive(
+                    'roommate gone');
+                FHEM::Automation::ShuttersControl::ShuttersCommandSet(
+                    $hash,
+                    $shuttersDev,
+                    $FHEM::Automation::ShuttersControl::shutters->getClosedPos
+                );
+            }
+            elsif ($getIsDay
+                && $FHEM::Automation::ShuttersControl::shutters->getModeUp eq
+                'gone'
+                && $getRoommatesStatus eq 'gone' )
+            {
+                ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate Up: $shuttersDev"
+                );
+
+                $FHEM::Automation::ShuttersControl::shutters->setLastDrive(
+                    'roommate gone');
+                FHEM::Automation::ShuttersControl::ShuttersCommandSet( $hash,
+                    $shuttersDev,
+                    $FHEM::Automation::ShuttersControl::shutters->getOpenPos );
+            }
+
+            ::Log3( $name, 4,
+"AutoShuttersControl ($name) - EventProcessingRoommate NICHTS: $shuttersDev"
+            );
+        } #end postfux added rommate gone condition
+    }
+    
     return;
 }
 

--- a/lib/FHEM/Automation/ShuttersControl/EventProcessingFunctions.pm
+++ b/lib/FHEM/Automation/ShuttersControl/EventProcessingFunctions.pm
@@ -749,7 +749,9 @@ sub EventProcessingRoommate {
                     && !$FHEM::Automation::ShuttersControl::shutters
                     ->getSelfDefenseState
                    && (($FHEM::Automation::ShuttersControl::shutters
-                        ->getShadingMode eq 'home' ) ) # added by postfux for not Shading when change form absent or gone to home
+                        ->getShadingMode eq 'home' ) ) 
+                        # added by postfux only when ShadingMode is home 
+                        # and not when absent or gone.
                   )
                 {
                     ShadingProcessingDriveCommand( $hash, $shuttersDev, 1 );


### PR DESCRIPTION
fixed shading when changing from absend/gone to home; added shading mode gone

Hi ich hatte in den letzten Tagen leider noch immer Probleme mit dem Shading, 
Wenn der Anwesenheitsstatus von absent auf home wechselte.
Ich habe mich deshalb mit dem Code auseinandergesetzt und das Problem scheinbar herausgefunden.

In der Funktion EventProcessingRoommate wird beim wechsel von absent/gone zu home 
die Funktion ShadingProzessingDriveCommand  aufgerufen. Dies bewirkt beim heimkommen 
die Beschattung.

Dann habe ich gleich noch shading mode gone eingebaut.

Hoffe das ist für jemand anderen auch nützlich.
LG Markus